### PR TITLE
Fix broken release script

### DIFF
--- a/goreleaser-post-hook.ps1
+++ b/goreleaser-post-hook.ps1
@@ -4,7 +4,7 @@ Write-Output "moving bazel outputs to goreleaser dist directory for packaging...
 
 # this gets invoked several times by goreleaser, we already have all the artifacts
 # from bazel so just copy them once
-if (-Not (Test-Path (Resolve-Path "dist"))) {
-  New-Item -Force -Path (Get-Location).Path -Name "dist"
+if (-Not (Test-Path "dist")) {
+  New-Item -Force -Path (Get-Location).Path -Name "dist" -ItemType "directory"
   Copy-Item (Resolve-Path "bazel-bin/bdist/*") -Destination (Resolve-Path "dist") -Recurse -Force
 }


### PR DESCRIPTION
this was not copying the built items into the goreleaser
tree, so we were publishing dummy binaries