### PR TITLE
Fix excessive rebuilds of nextjs

### DIFF
--- a/cmd/lighting.go
+++ b/cmd/lighting.go
@@ -130,8 +130,8 @@ func init() {
 		"off":         "/press/bank/20/14",
 		"ftb":         "/press/bank/20/4",
 		"dsk":         "/press/bank/20/5",
-		"keylighton":  "/press/bank/20/2",
-		"keylightoff": "/press/bank/20/3",
+		"keylighton":  "/press/bank/20/18",
+		"keylightoff": "/press/bank/20/19",
 	})
 
 	rootCmd.AddCommand(lightingBridgeCmd)

--- a/embeddy/BUILD.bazel
+++ b/embeddy/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@npm//next:index.bzl", "next")
-load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
-load("//:glue.bzl", "static_site_embedder")
+
+load("//:glue.bzl", "embed_nextjs")
 
 filegroup(
     name = "source_files",
@@ -20,33 +19,9 @@ filegroup(
     ],
 )
 
-copy_to_bin(
-    name = "copy_source_files",
-    srcs = [":source_files"],
-)
-
-next(
-    name = "next_build",
-    outs = [".next"],
-    args = ["build $(RULEDIR)"],
-    data = [":copy_source_files"],  # + NPM_DEPENDENCIES,
-    tags = ["no-sandbox"],
-)
-
-next(
-    name = "next_export",
-    outs = ["dist"],
-    args = [
-        "export $(RULEDIR)",
-        "-o $(@)",
-    ],
-    data = [":next_build"],
-    visibility = ["//visibility:public"],
-)
-
-static_site_embedder(
+embed_nextjs(
     name = "embedder",
-    srcs = [":dist"],
+    srcs = [":source_files"],
 )
 
 # keep

--- a/embeddy/pages/index.js
+++ b/embeddy/pages/index.js
@@ -37,6 +37,11 @@ export default function Home() {
 
     sendRequest("/api/light/off");
   };
+  const sendBRB = (event) => {
+    event.preventDefault();
+
+    sendRequest("/api/switcher/brb");
+  };
   const sendFTB = (event) => {
     event.preventDefault();
 

--- a/glue.bzl
+++ b/glue.bzl
@@ -1,3 +1,8 @@
+"""
+Bazel macro for building an embedded NextJS app into a go library.
+"""
+load("@npm//next:index.bzl", "next")
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
 
 def _static_site_embedder_impl(ctx):
     #tree = ctx.actions.declare_directory(ctx.attr.name + ".artifacts")
@@ -32,3 +37,52 @@ site build and embedding or publishing.
         "embedder": "embedder.go",
     },
 )
+
+def embed_nextjs(name, srcs = [], visibility=None, **kwargs):
+    """
+    Embeds a static site into a go library.
+
+    This is useful for collecting together the generated files from a static
+    site build and embedding or publishing.
+
+    Args:
+        name: Name of the embedder.
+        srcs: List of files to embed.
+        visibility: Visibility of the embedder.
+        **kwargs: Additional arguments to pass to the embedder rule.
+
+    Returns:
+        A label pointing to the embedder.
+    """
+    copy_to_bin(
+        name = "copy_source_files",
+        srcs = srcs,
+        visibility = ["//visibility:private"],
+    )
+
+    next(
+        name = "next_build",
+        outs = [".next/build-manifest.json"],
+        args = ["build $(RULEDIR)"],
+        data = [":copy_source_files"],  # + NPM_DEPENDENCIES,
+        # tags = ["no-sandbox"],
+        visibility = ["//visibility:private"],
+    )
+
+    next(
+        name = "next_export",
+        outs = ["dist"],
+        args = [
+            "export $(RULEDIR)",
+            "-o $(@)",
+        ],
+        data = [":next_build"],
+        visibility = ["//visibility:private"],
+    )
+
+    return static_site_embedder(
+        name = name,
+        srcs = [":dist"],
+        visibility = visibility,
+        **kwargs
+    )


### PR DESCRIPTION
Use a build manifest sentinel file for the output of the
nextjs build rule.

Tidy nextjs build/export by wrapping inside a bazel macro
along with the go generation code for the embedded filesystem.

The end result of this is that iterating on go code is much
faster because there are no longer spurious rebuilds of nextjs
when no nextjs source code has changed.