### PR TITLE
Revert "go 1.19"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-hoist=false

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.19.1")
+go_register_toolchains(version = "1.18.4")
 
 http_archive(
     name = "bazel_gazelle",

--- a/embeddy/patches/next+12.0.3.patch
+++ b/embeddy/patches/next+12.0.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/next/dist/build/is-writeable.js b/node_modules/next/dist/build/is-writeable.js
-index 679e1e5..c8e93a9 100644
+index 679e1e5..9cbac0e 100644
 --- a/node_modules/next/dist/build/is-writeable.js
 +++ b/node_modules/next/dist/build/is-writeable.js
 @@ -14,7 +14,10 @@ async function isWriteable(directory) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kindlyops/vbs
 
-go 1.19
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.116

--- a/vendor.sh
+++ b/vendor.sh
@@ -8,11 +8,10 @@ gazelle="$PWD/$1"
 echo "Using these commands"
 command -v go
 echo "$gazelle"
-echo "workspace directory is $BUILD_WORKSPACE_DIRECTORY"
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
-go mod tidy
+go mod tidy -compat=1.18
 go mod vendor
 $gazelle
 


### PR DESCRIPTION
Reverts kindlyops/vbs#514

The embedding for pocketbase isn't working with go 1.19