### PR TITLE
Fix scorecards workflow permissions for Sigstore signing

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main" ]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions: {}  # Set permissions at job level instead
 
 jobs:
   analysis:


### PR DESCRIPTION
Update top-level permissions from read-all to empty object to allow job-level id-token: write permission to take effect. This fixes the Fulcio signing error when publish_results is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)