### PR TITLE
Fix oci_push IMAGE_TAG variable expansion

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -107,7 +107,7 @@ oci_push(
     name = "push_image",
     image = ":vbs_image",
     repository = "ghcr.io/kindlyops/vbs",
-    remote_tags = ["$(IMAGE_TAG)"],
+    remote_tags = ["{IMAGE_TAG}"],
     tags = ["manual"],
 )
 


### PR DESCRIPTION
## Summary
- Fix IMAGE_TAG variable expansion in oci_push rule by changing from Make-style `$(IMAGE_TAG)` to Bazel stamping syntax `{IMAGE_TAG}`

This resolves the 404 error when pushing images where the literal string `$(IMAGE_TAG)` was being sent as the manifest tag instead of the actual value.

## Test plan
- [ ] Run `bazel run --define=IMAGE_TAG=experimental.main --stamp //:push_image` and verify the image pushes successfully
- [ ] Verify the correct tag appears in the container registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)