### PR TITLE
Add plt print command for purple playlists

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,3 +35,12 @@ jobs:
           reporter: github-pr-review
           github_token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           golangci_lint_flags: "--config=.golangci.yml"
+  vendor-neutral:
+    name: runner / vendor-neutral
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: vendor-neutrality guard
+        run: ./scripts/check-vendor-neutral.sh

--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ vbs chapterlist file.mp4
 vbs chaptersplit file.mp4
 ```
 
+## plt - purple playlists
+
+Parse purple playlist exports (a ZIP container with a SQLite database produced
+by the source app) and prepare their media for live meetings run from Mitti.
+
+### Print a playlist
+
+Parse a playlist and print its cues as an aligned table. Works entirely
+offline; no media is downloaded.
+
+```bash
+vbs plt print meeting.playlist
+```
+
+Use `--json` to emit the same data as JSON:
+
+```bash
+vbs plt print --json meeting.playlist
+```
+
+The format is detected by content, not file extension, so a renamed export is
+still recognized. Invalid files are rejected with a message naming what was
+wrong (not a zip, missing manifest, non-SQLite database, or missing tables).
+
 ## installation for homebrew (MacOS/Linux)
 
     brew install kindlyops/tap/vbs

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -10,6 +10,9 @@ go_library(
         "play.go",
         "play_unix.go",
         "play_windows.go",
+        "plt.go",
+        "plt_helpers.go",
+        "plt_parse.go",
         "root.go",
     ],
     importpath = "github.com/kindlyops/vbs/cmd",
@@ -37,6 +40,7 @@ go_library(
         "//vendor/github.com/rs/zerolog:go_default_library",
         "//vendor/github.com/rs/zerolog/log:go_default_library",
         "//vendor/github.com/spf13/viper:go_default_library",
+        "//vendor/modernc.org/sqlite:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:windows": [
             "//vendor/github.com/Microsoft/go-winio:go_default_library",
@@ -50,11 +54,17 @@ go_test(
     srcs = [
         "chapters_test.go",
         "lighting_test.go",
+        "plt_fixture_test.go",
+        "plt_helpers_test.go",
+        "plt_parse_test.go",
+        "plt_print_test.go",
+        "plt_sniff_test.go",
         "root_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/rs/zerolog:go_default_library",
         "//vendor/github.com/spf13/viper:go_default_library",
+        "//vendor/modernc.org/sqlite:go_default_library",
     ],
 )

--- a/cmd/plt.go
+++ b/cmd/plt.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -49,12 +50,7 @@ offline; no media is downloaded.`,
 }
 
 func runPltPrint(_ *coral.Command, args []string) {
-	path := resolveInputPath(args[0])
-
-	arc, err := sniffPlaylist(path)
-	if err != nil {
-		log.Fatal().Err(err).Msgf("Not a valid purple playlist: %s", path)
-	}
+	arc := openPlaylist(args[0])
 	defer func() { _ = arc.Close() }()
 
 	if arc.schemaVersion != verifiedSchemaVersion {
@@ -91,6 +87,35 @@ func resolveInputPath(p string) string {
 		return filepath.Join(wd, p)
 	}
 	return p
+}
+
+// checkPlaylistFile reports a clear, path-focused error when the file is
+// missing or unreadable, keeping it distinct from a format-validation failure.
+func checkPlaylistFile(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no such file: %s", path)
+		}
+		return fmt.Errorf("could not access %s: %w", path, err)
+	}
+	return nil
+}
+
+// openPlaylist resolves the argument, fails fast with a distinct message when
+// the file is missing, then sniffs and returns the validated archive. Shared
+// by the print and build commands.
+func openPlaylist(rawPath string) *archive {
+	path := resolveInputPath(rawPath)
+
+	if err := checkPlaylistFile(path); err != nil {
+		log.Fatal().Err(err).Msg("Could not open playlist file")
+	}
+
+	arc, err := sniffPlaylist(path)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Not a valid purple playlist: %s", path)
+	}
+	return arc
 }
 
 // printView is the offline summary rendered by plt print, shared by the text

--- a/cmd/plt.go
+++ b/cmd/plt.go
@@ -1,0 +1,211 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/muesli/coral"
+	"github.com/rs/zerolog/log"
+)
+
+var pltPrintJSON bool
+
+var pltCmd = &coral.Command{
+	Use:   "plt",
+	Short: "Work with purple playlists.",
+	Long: `Parse, build, and prepare media for purple playlist exports from the
+source app for use in live meetings.`,
+}
+
+var pltPrintCmd = &coral.Command{
+	Use:   "print <playlist>",
+	Short: "Parse and pretty-print a purple playlist.",
+	Long: `Parse a purple playlist export and print its cues. Works entirely
+offline; no media is downloaded.`,
+	Run:  runPltPrint,
+	Args: coral.ExactArgs(1),
+}
+
+func runPltPrint(cmd *coral.Command, args []string) {
+	path := args[0]
+
+	arc, err := sniffPlaylist(path)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Not a valid purple playlist: %s", path)
+	}
+	defer func() { _ = arc.Close() }()
+
+	if arc.schemaVersion != verifiedSchemaVersion {
+		log.Warn().Msgf("schema version %d differs from verified version %d; proceeding because required tables are present",
+			arc.schemaVersion, verifiedSchemaVersion)
+	}
+
+	pl, err := parsePlaylist(arc)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Could not parse playlist")
+	}
+
+	view := buildPrintView(pl)
+
+	if pltPrintJSON {
+		err = renderJSON(os.Stdout, view)
+	} else {
+		err = renderText(os.Stdout, view)
+	}
+	if err != nil {
+		log.Fatal().Err(err).Msg("Could not render playlist")
+	}
+}
+
+// printView is the offline summary rendered by plt print, shared by the text
+// and JSON outputs so both show the same data.
+type printView struct {
+	Name  string      `json:"name"`
+	Items []printItem `json:"items"`
+}
+
+type printItem struct {
+	Position    int           `json:"position"`
+	Label       string        `json:"label"`
+	Source      string        `json:"source"`
+	Kind        string        `json:"kind"`
+	DurationSec float64       `json:"durationSec"`
+	EndAction   int           `json:"endAction"`
+	Markers     []printMarker `json:"markers,omitempty"`
+}
+
+type printMarker struct {
+	Label       string  `json:"label"`
+	StartSec    float64 `json:"startSec"`
+	DurationSec float64 `json:"durationSec"`
+}
+
+// buildPrintView projects the parsed playlist into the print summary.
+func buildPrintView(pl *Playlist) printView {
+	view := printView{Name: pl.Name, Items: make([]printItem, 0, len(pl.Items))}
+
+	for _, it := range pl.Items {
+		pi := printItem{
+			Position:    it.Position,
+			Label:       it.Label,
+			Source:      describeSource(it),
+			Kind:        itemKind(it),
+			DurationSec: itemDurationSec(it),
+			EndAction:   it.EndAction,
+		}
+		for _, m := range it.Markers {
+			pi.Markers = append(pi.Markers, printMarker{
+				Label:       m.Label,
+				StartSec:    ticksToSeconds(m.StartTimeTicks),
+				DurationSec: ticksToSeconds(m.DurationTicks),
+			})
+		}
+		view.Items = append(view.Items, pi)
+	}
+	return view
+}
+
+// describeSource renders a one-line description of where an item's media comes
+// from, following the catalog resolution rule (KeySymbol+Track, book/chapter, docid).
+func describeSource(it Item) string {
+	if it.IsImage() {
+		return "embedded image"
+	}
+
+	loc := it.Location
+	if loc == nil {
+		return "unknown source"
+	}
+
+	switch {
+	case loc.KeySymbol == "nwt" && loc.BookNumber > 0:
+		return fmt.Sprintf("book %d:%d", loc.BookNumber, loc.ChapterNumber)
+	case loc.KeySymbol != "" && loc.Track > 0:
+		return fmt.Sprintf("pub %s track %d", loc.KeySymbol, loc.Track)
+	case loc.Type == 3 && loc.DocumentID > 0:
+		return fmt.Sprintf("docid %d", loc.DocumentID)
+	default:
+		return fmt.Sprintf("unsupported location (type %d)", loc.Type)
+	}
+}
+
+// itemKind reports "image" or "video" for an item.
+func itemKind(it Item) string {
+	if it.IsImage() {
+		return "image"
+	}
+	return "video"
+}
+
+// itemDurationSec returns the cue's nominal duration in seconds.
+func itemDurationSec(it Item) float64 {
+	if it.IsImage() {
+		return ticksToSeconds(it.Image.DurationTicks)
+	}
+	if it.Location != nil {
+		return ticksToSeconds(it.Location.BaseDurationTicks)
+	}
+	return 0
+}
+
+// renderJSON writes the print view as indented JSON.
+func renderJSON(w io.Writer, view printView) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(view); err != nil {
+		return fmt.Errorf("could not encode JSON: %w", err)
+	}
+	return nil
+}
+
+// renderText writes the print view as an aligned table.
+func renderText(w io.Writer, view printView) error {
+	if _, err := fmt.Fprintf(w, "Playlist: %s\n\n", view.Name); err != nil {
+		return fmt.Errorf("could not write header: %w", err)
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "#\tLABEL\tSOURCE\tDURATION\tMARKERS\tEND"); err != nil {
+		return fmt.Errorf("could not write table header: %w", err)
+	}
+
+	for _, it := range view.Items {
+		markers := ""
+		if len(it.Markers) > 0 {
+			markers = fmt.Sprintf("%d", len(it.Markers))
+		}
+		if _, err := fmt.Fprintf(tw, "%d\t%s\t%s\t%.1fs\t%s\t%d\n",
+			it.Position, it.Label, it.Source, it.DurationSec, markers, it.EndAction); err != nil {
+			return fmt.Errorf("could not write table row: %w", err)
+		}
+	}
+
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("could not flush table: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	pltPrintCmd.Flags().BoolVar(&pltPrintJSON, "json", false, "emit the playlist as JSON instead of a table")
+
+	pltCmd.AddCommand(pltPrintCmd)
+	rootCmd.AddCommand(pltCmd)
+}

--- a/cmd/plt.go
+++ b/cmd/plt.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/muesli/coral"
@@ -28,23 +29,27 @@ import (
 var pltPrintJSON bool
 
 var pltCmd = &coral.Command{
-	Use:   "plt",
+	Use:   "plt <command> <playlist-file>",
 	Short: "Work with purple playlists.",
 	Long: `Parse, build, and prepare media for purple playlist exports from the
-source app for use in live meetings.`,
+source app for use in live meetings. Each subcommand takes the path to a
+playlist export file.`,
+	Example: `  vbs plt print meeting.playlist
+  vbs plt build meeting.playlist`,
 }
 
 var pltPrintCmd = &coral.Command{
-	Use:   "print <playlist>",
+	Use:   "print <playlist-file>",
 	Short: "Parse and pretty-print a purple playlist.",
 	Long: `Parse a purple playlist export and print its cues. Works entirely
 offline; no media is downloaded.`,
-	Run:  runPltPrint,
-	Args: coral.ExactArgs(1),
+	Example: "  vbs plt print meeting.playlist",
+	Run:     runPltPrint,
+	Args:    coral.ExactArgs(1),
 }
 
-func runPltPrint(cmd *coral.Command, args []string) {
-	path := args[0]
+func runPltPrint(_ *coral.Command, args []string) {
+	path := resolveInputPath(args[0])
 
 	arc, err := sniffPlaylist(path)
 	if err != nil {
@@ -72,6 +77,20 @@ func runPltPrint(cmd *coral.Command, args []string) {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not render playlist")
 	}
+}
+
+// resolveInputPath makes a user-supplied path usable regardless of how the
+// binary was launched. Relative paths are resolved against the directory the
+// command was invoked from; under `bazel run` that is reported via
+// BUILD_WORKING_DIRECTORY, since the process itself starts in the runfiles tree.
+func resolveInputPath(p string) string {
+	if p == "" || filepath.IsAbs(p) {
+		return p
+	}
+	if wd := os.Getenv("BUILD_WORKING_DIRECTORY"); wd != "" {
+		return filepath.Join(wd, p)
+	}
+	return p
 }
 
 // printView is the offline summary rendered by plt print, shared by the text

--- a/cmd/plt_fixture_test.go
+++ b/cmd/plt_fixture_test.go
@@ -1,0 +1,258 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"image"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// fixtureOptions controls how a synthetic playlist export is built so that
+// individual sniffer/parser cases can request a deliberately broken file.
+// The zero value produces a valid schema-14 export covering every source shape.
+type fixtureOptions struct {
+	schemaVersion int
+	omitTables    []string // tables to drop from the created database
+	omitManifest  bool     // build a zip with no manifest.json
+	notZip        bool     // write raw bytes instead of a zip archive
+	corruptDB     bool     // store non-SQLite bytes where the database belongs
+	databaseName  string   // manifest databaseName (defaults to userData.db)
+}
+
+const fixtureThumbA = "11111111-1111-1111-1111-111111111111.jpg"
+const fixtureThumbBook = "22222222-2222-2222-2222-222222222222.jpg"
+const fixtureThumbImage = "33333333-3333-3333-3333-333333333333.jpg"
+const fixtureThumbDocid = "44444444-4444-4444-4444-444444444444.jpg"
+const fixtureImageFile = "55555555-5555-5555-5555-555555555555.jpg"
+
+// writePlaylistFixture creates a synthetic export on disk and returns its path.
+// It never copies any real export; everything is generated.
+func writePlaylistFixture(t *testing.T, opts fixtureOptions) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "test-export")
+
+	if opts.notZip {
+		if err := os.WriteFile(out, []byte("this is not a zip archive"), 0o600); err != nil {
+			t.Fatalf("write non-zip fixture: %v", err)
+		}
+		return out
+	}
+
+	dbName := opts.databaseName
+	if dbName == "" {
+		dbName = "userData.db"
+	}
+
+	var dbBytes []byte
+	if opts.corruptDB {
+		dbBytes = []byte("not a real database")
+	} else {
+		dbBytes = buildFixtureDB(t, dir, opts.omitTables)
+	}
+
+	files := map[string][]byte{
+		dbName:            dbBytes,
+		fixtureThumbA:     onePixelJPEG(t),
+		fixtureThumbBook: onePixelJPEG(t),
+		fixtureThumbImage: onePixelJPEG(t),
+		fixtureThumbDocid: onePixelJPEG(t),
+		fixtureImageFile:  onePixelJPEG(t),
+	}
+
+	if !opts.omitManifest {
+		files["manifest.json"] = fixtureManifest(t, dbName, opts.schemaVersion)
+	}
+
+	writeZip(t, out, files)
+	return out
+}
+
+// fixtureManifest renders a manifest.json mirroring the observed shape.
+func fixtureManifest(t *testing.T, dbName string, schemaVersion int) []byte {
+	t.Helper()
+
+	if schemaVersion == 0 {
+		schemaVersion = verifiedSchemaVersion
+	}
+
+	manifest := map[string]any{
+		"version": 1,
+		"userDataBackup": map[string]any{
+			"schemaVersion": schemaVersion,
+			"databaseName":  dbName,
+			"deviceName":    "synthetic",
+		},
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return data
+}
+
+// writeZip assembles a zip archive from the given entries.
+func writeZip(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	for name, body := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", name, err)
+		}
+		if _, err := w.Write(body); err != nil {
+			t.Fatalf("zip write %s: %v", name, err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write zip: %v", err)
+	}
+}
+
+// onePixelJPEG returns the bytes of a 1x1 JPEG image.
+func onePixelJPEG(t *testing.T) []byte {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatalf("encode jpeg: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// buildFixtureDB creates the SQLite database file and returns its bytes.
+func buildFixtureDB(t *testing.T, dir string, omit []string) []byte {
+	t.Helper()
+
+	dbPath := filepath.Join(dir, "fixture.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	omitted := make(map[string]bool, len(omit))
+	for _, name := range omit {
+		omitted[name] = true
+	}
+
+	for _, stmt := range fixtureSchema(omitted) {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec schema: %v\n%s", err, stmt)
+		}
+	}
+	// Negative fixtures that drop a table only exercise the table check, which
+	// runs before parsing, so they need no row data.
+	if len(omit) == 0 {
+		for _, stmt := range fixtureData() {
+			if _, err := db.Exec(stmt); err != nil {
+				t.Fatalf("exec data: %v\n%s", err, stmt)
+			}
+		}
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	body, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("read db: %v", err)
+	}
+	return body
+}
+
+// fixtureSchema returns CREATE statements for every table except those omitted.
+func fixtureSchema(omit map[string]bool) []string {
+	tables := map[string]string{
+		"Tag":                     `CREATE TABLE Tag (TagId INTEGER PRIMARY KEY, Name TEXT, Type INTEGER)`,
+		"TagMap":                  `CREATE TABLE TagMap (TagMapId INTEGER PRIMARY KEY, TagId INTEGER, PlaylistItemId INTEGER, Position INTEGER)`,
+		"PlaylistItem":            `CREATE TABLE PlaylistItem (PlaylistItemId INTEGER PRIMARY KEY, Label TEXT, StartTrimOffsetTicks INTEGER, EndTrimOffsetTicks INTEGER, EndAction INTEGER, ThumbnailFilePath TEXT)`,
+		"PlaylistItemLocationMap": `CREATE TABLE PlaylistItemLocationMap (PlaylistItemId INTEGER, LocationId INTEGER, MajorMultimediaType INTEGER, BaseDurationTicks INTEGER)`,
+		"Location":                `CREATE TABLE Location (LocationId INTEGER PRIMARY KEY, BookNumber INTEGER, ChapterNumber INTEGER, DocumentId INTEGER, Track INTEGER, KeySymbol TEXT, MepsLanguage INTEGER, Type INTEGER)`,
+		"IndependentMedia":        `CREATE TABLE IndependentMedia (IndependentMediaId INTEGER PRIMARY KEY, OriginalFilename TEXT, FilePath TEXT, MimeType TEXT, Hash TEXT)`,
+		"PlaylistItemIndependentMediaMap": `CREATE TABLE PlaylistItemIndependentMediaMap ` +
+			`(PlaylistItemId INTEGER, IndependentMediaId INTEGER, DurationTicks INTEGER)`,
+		"PlaylistItemMarker": `CREATE TABLE PlaylistItemMarker (PlaylistItemMarkerId INTEGER PRIMARY KEY, ` +
+			`PlaylistItemId INTEGER, Label TEXT, StartTimeTicks INTEGER, DurationTicks INTEGER, ` +
+			`EndTransitionDurationTicks INTEGER)`,
+	}
+
+	order := []string{
+		"Tag", "TagMap", "PlaylistItem", "PlaylistItemLocationMap", "Location",
+		"IndependentMedia", "PlaylistItemIndependentMediaMap", "PlaylistItemMarker",
+	}
+
+	var stmts []string
+	for _, name := range order {
+		if omit[name] {
+			continue
+		}
+		stmts = append(stmts, tables[name])
+	}
+	return stmts
+}
+
+// fixtureData returns INSERT statements describing the four-cue playlist:
+// a pub/track song, a book/chapter item with two contiguous markers plus one
+// separate marker, an image cue, and a docid item.
+func fixtureData() []string {
+	return []string{
+		`INSERT INTO Tag (TagId, Name, Type) VALUES (1, 'synthetic event', 2)`,
+
+		`INSERT INTO PlaylistItem VALUES (1, 'First Clip', 0, 0, 2, '` + fixtureThumbA + `')`,
+		`INSERT INTO PlaylistItem VALUES (2, 'Marked Clip', 0, 0, 2, '` + fixtureThumbBook + `')`,
+		`INSERT INTO PlaylistItem VALUES (3, 'picture.jpg', 0, 0, 0, '` + fixtureThumbImage + `')`,
+		`INSERT INTO PlaylistItem VALUES (4, 'Downloaded Video Clip', 0, 0, 2, '` + fixtureThumbDocid + `')`,
+
+		`INSERT INTO TagMap VALUES (1, 1, 1, 0)`,
+		`INSERT INTO TagMap VALUES (2, 1, 2, 1)`,
+		`INSERT INTO TagMap VALUES (3, 1, 3, 2)`,
+		`INSERT INTO TagMap VALUES (4, 1, 4, 3)`,
+
+		`INSERT INTO Location VALUES (1, NULL, NULL, 1102016935, 135, 'sjj', 420, 0)`,
+		`INSERT INTO Location VALUES (2, 23, 5, NULL, NULL, 'nwt', 420, 0)`,
+		`INSERT INTO Location VALUES (4, NULL, NULL, 1112024040, 1, NULL, 420, 3)`,
+
+		`INSERT INTO PlaylistItemLocationMap VALUES (1, 1, 2, 1390060000)`,
+		`INSERT INTO PlaylistItemLocationMap VALUES (2, 2, 2, 542530000)`,
+		`INSERT INTO PlaylistItemLocationMap VALUES (4, 4, 2, 7935420000)`,
+
+		`INSERT INTO IndependentMedia VALUES (1, 'picture.jpg', '` + fixtureImageFile + `', 'image/jpeg', 'abc123')`,
+		`INSERT INTO PlaylistItemIndependentMediaMap VALUES (3, 1, 40000000)`,
+
+		`INSERT INTO PlaylistItemMarker VALUES (1, 2, 'Marker one', 20680000, 186510000, 0)`,
+		`INSERT INTO PlaylistItemMarker VALUES (2, 2, 'Marker two', 207200000, 356020000, 0)`,
+		`INSERT INTO PlaylistItemMarker VALUES (3, 2, 'Marker three', 1257580000, 372370000, 12340000)`,
+	}
+}

--- a/cmd/plt_helpers.go
+++ b/cmd/plt_helpers.go
@@ -1,0 +1,104 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ticksPerSecond converts .NET-style 100-nanosecond ticks to seconds.
+const ticksPerSecond = 10_000_000
+
+// languageNames maps numeric MepsLanguage IDs to their written-language codes.
+// The source app identifies languages by integer; only verified IDs are listed.
+var languageNames = map[int]string{
+	420: "ASL",
+}
+
+// ticksToSeconds converts a 100-nanosecond tick count to seconds.
+func ticksToSeconds(ticks int64) float64 {
+	return float64(ticks) / float64(ticksPerSecond)
+}
+
+// resolveLanguage returns the written-language code for a MepsLanguage ID.
+// A non-empty override always wins; otherwise the embedded map is consulted
+// and an unmapped ID is a fatal error naming the override flag.
+func resolveLanguage(id int, override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+
+	if code, ok := languageNames[id]; ok {
+		return code, nil
+	}
+
+	return "", fmt.Errorf("unknown language id %d; set it explicitly with --lang", id)
+}
+
+// slugify renders a display name as a filesystem-safe slug: lowercase ASCII
+// letters, digits, and hyphens. Apostrophes are dropped (so "don't" becomes
+// "dont"); every other non-alphanumeric rune becomes a separator. Runs of
+// separators collapse to one hyphen and leading/trailing hyphens are trimmed.
+func slugify(s string) string {
+	var b strings.Builder
+
+	for _, r := range s {
+		r = unicode.ToLower(r)
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		case r == '\'' || r == '’' || r == '‘':
+			// drop apostrophes so possessives stay one word
+		default:
+			b.WriteByte('-')
+		}
+	}
+
+	return strings.Trim(collapseHyphens(b.String()), "-")
+}
+
+// collapseHyphens replaces runs of hyphens with a single hyphen.
+func collapseHyphens(s string) string {
+	var b strings.Builder
+
+	prevHyphen := false
+	for _, r := range s {
+		if r == '-' {
+			if !prevHyphen {
+				b.WriteRune(r)
+			}
+			prevHyphen = true
+			continue
+		}
+
+		b.WriteRune(r)
+		prevHyphen = false
+	}
+
+	return b.String()
+}
+
+// uniqueSlug returns base, or base-2/base-3/... when base was already issued.
+// seen tracks how many times each base has been requested.
+func uniqueSlug(base string, seen map[string]int) string {
+	seen[base]++
+	if seen[base] == 1 {
+		return base
+	}
+
+	return fmt.Sprintf("%s-%d", base, seen[base])
+}

--- a/cmd/plt_helpers_test.go
+++ b/cmd/plt_helpers_test.go
@@ -1,0 +1,117 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTicksToSeconds(t *testing.T) {
+	cases := []struct {
+		name  string
+		ticks int64
+		want  float64
+	}{
+		{"zero", 0, 0},
+		{"verified song duration", 1390060000, 139.006},
+		{"marker start", 20680000, 2.068},
+		{"marker two start", 207200000, 20.72},
+		{"image cue 4s", 40000000, 4.0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ticksToSeconds(tc.ticks)
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Errorf("ticksToSeconds(%d) = %v, want %v", tc.ticks, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveLanguage(t *testing.T) {
+	cases := []struct {
+		name     string
+		id       int
+		override string
+		wantCode string
+		wantErr  bool
+	}{
+		{"known id ASL", 420, "", "ASL", false},
+		{"override wins over known", 420, "ESL", "ESL", false},
+		{"override fills unknown", 999, "FOO", "FOO", false},
+		{"unknown id is fatal", 999, "", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := resolveLanguage(tc.id, tc.override)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveLanguage(%d, %q) expected error, got nil", tc.id, tc.override)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveLanguage(%d, %q) unexpected error: %v", tc.id, tc.override, err)
+			}
+			if code != tc.wantCode {
+				t.Errorf("resolveLanguage(%d, %q) = %q, want %q", tc.id, tc.override, code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "event Dec 2nd", "event-dec-2nd"},
+		{"em dash", "40—Two Part Name", "40-two-part-name"},
+		{"curly quotes", "4. “Quoted Heading”", "4-quoted-heading"},
+		{"curly apostrophe dropped", "12. It’s a Heading:", "12-its-a-heading"},
+		{"colon comma run", "Part 1 Section 5:1, 2", "part-1-section-5-1-2"},
+		{"straight apostrophe dropped", "Don't Stop", "dont-stop"},
+		{"leading trailing junk", "  --Hello--  ", "hello"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := slugify(tc.in)
+			if got != tc.want {
+				t.Errorf("slugify(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUniqueSlug(t *testing.T) {
+	seen := map[string]int{}
+	got := []string{
+		uniqueSlug("talk", seen),
+		uniqueSlug("talk", seen),
+		uniqueSlug("talk", seen),
+		uniqueSlug("other", seen),
+	}
+	want := []string{"talk", "talk-2", "talk-3", "other"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("uniqueSlug call %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/cmd/plt_parse.go
+++ b/cmd/plt_parse.go
@@ -1,0 +1,491 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "modernc.org/sqlite" // registers the pure-Go "sqlite" database/sql driver
+)
+
+const sqliteMagic = "SQLite format 3\x00"
+
+var zipMagic = []byte("PK\x03\x04")
+
+// verifiedSchemaVersion is the source-app backup schema version this parser
+// was validated against. Other versions warn but still proceed when the
+// required tables are present — the tables are the real contract.
+const verifiedSchemaVersion = 14
+
+// requiredTables are the database tables the parser depends on. Their presence
+// is the contract that lets us read a playlist regardless of schema version.
+var requiredTables = []string{
+	"Tag",
+	"TagMap",
+	"PlaylistItem",
+	"PlaylistItemLocationMap",
+	"Location",
+	"IndependentMedia",
+	"PlaylistItemMarker",
+}
+
+// Playlist is the ordered, parsed contents of a purple playlist export.
+type Playlist struct {
+	Name          string
+	SchemaVersion int
+	DatabaseName  string
+	Items         []Item
+}
+
+// Item is a single cue in playback order.
+type Item struct {
+	Position       int
+	PlaylistItemID int64
+	Label          string
+	StartTrimTicks int64
+	EndTrimTicks   int64
+	EndAction      int
+	ThumbnailPath  string
+	Location       *Location
+	Image          *EmbeddedImage
+	Markers        []Marker
+}
+
+// IsImage reports whether the item is an image cue (embedded media) rather
+// than a reference to published video.
+func (i Item) IsImage() bool {
+	return i.Image != nil
+}
+
+// Location identifies published media referenced from the publisher's catalog.
+// Absent numeric columns are represented as zero; KeySymbol is empty when null.
+type Location struct {
+	MajorMultimediaType int
+	BaseDurationTicks   int64
+	BookNumber          int64
+	ChapterNumber       int64
+	DocumentID          int64
+	Track               int64
+	KeySymbol           string
+	MepsLanguage        int
+	Type                int
+}
+
+// EmbeddedImage is media shipped inside the export zip (an image cue).
+type EmbeddedImage struct {
+	DurationTicks    int64
+	OriginalFilename string
+	FilePath         string
+	MimeType         string
+	Hash             string
+}
+
+// Marker is a sub-clip range within a referenced video.
+type Marker struct {
+	Label                      string
+	StartTimeTicks             int64
+	DurationTicks              int64
+	EndTransitionDurationTicks int64
+}
+
+// archive is a sniffed, validated export ready to be parsed. The database has
+// been extracted to a temp directory; Close removes it. The original zip path
+// is retained so later phases can extract images without re-validating.
+type archive struct {
+	path          string
+	dbName        string
+	dbPath        string
+	tmpDir        string
+	schemaVersion int
+}
+
+// Close removes the temp directory holding the extracted database.
+func (a *archive) Close() error {
+	if a.tmpDir == "" {
+		return nil
+	}
+	return os.RemoveAll(a.tmpDir)
+}
+
+// manifestDoc is the subset of manifest.json the sniffer validates.
+type manifestDoc struct {
+	UserDataBackup struct {
+		SchemaVersion json.Number `json:"schemaVersion"`
+		DatabaseName  string      `json:"databaseName"`
+	} `json:"userDataBackup"`
+}
+
+// sniffPlaylist validates that path is a purple playlist export and extracts
+// its database. Each validation failure names what was wrong (see the format
+// sniffer spec): zip magic, manifest, SQLite database, required tables.
+func sniffPlaylist(path string) (*archive, error) {
+	if err := checkZipMagic(path); err != nil {
+		return nil, err
+	}
+
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		return nil, fmt.Errorf("not a zip archive: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	man, err := readManifest(&zr.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	dbEntry := findZipEntry(&zr.Reader, man.UserDataBackup.DatabaseName)
+	if dbEntry == nil {
+		return nil, fmt.Errorf("missing or non-SQLite database: manifest names %q but it is not in the archive",
+			man.UserDataBackup.DatabaseName)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "vbs-plt-")
+	if err != nil {
+		return nil, fmt.Errorf("could not create temp dir: %w", err)
+	}
+
+	dbPath, err := extractDatabase(dbEntry, tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, err
+	}
+
+	if err := verifyTables(dbPath); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, err
+	}
+
+	schemaVersion, _ := man.UserDataBackup.SchemaVersion.Int64()
+	return &archive{
+		path:          path,
+		dbName:        man.UserDataBackup.DatabaseName,
+		dbPath:        dbPath,
+		tmpDir:        tmpDir,
+		schemaVersion: int(schemaVersion),
+	}, nil
+}
+
+// parsePlaylist reads the validated archive's database into an ordered model.
+func parsePlaylist(a *archive) (*Playlist, error) {
+	db, err := sql.Open("sqlite", a.dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	name, err := queryPlaylistName(db)
+	if err != nil {
+		return nil, err
+	}
+
+	items, index, err := queryItems(db)
+	if err != nil {
+		return nil, err
+	}
+	if err := attachLocations(db, items, index); err != nil {
+		return nil, err
+	}
+	if err := attachImages(db, items, index); err != nil {
+		return nil, err
+	}
+	if err := attachMarkers(db, items, index); err != nil {
+		return nil, err
+	}
+
+	return &Playlist{
+		Name:          name,
+		SchemaVersion: a.schemaVersion,
+		DatabaseName:  a.dbName,
+		Items:         items,
+	}, nil
+}
+
+// queryPlaylistName returns the name of the playlist tag (Type 2).
+func queryPlaylistName(db *sql.DB) (string, error) {
+	var name string
+	err := db.QueryRow(`SELECT Name FROM Tag WHERE Type = 2`).Scan(&name)
+	if err != nil {
+		return "", fmt.Errorf("could not read playlist name: %w", err)
+	}
+	return name, nil
+}
+
+// queryItems returns the playlist items in playback order plus an index from
+// PlaylistItemId to the item's slice position, used to attach related rows.
+func queryItems(db *sql.DB) ([]Item, map[int64]int, error) {
+	rows, err := db.Query(`
+		SELECT tm.Position, pi.PlaylistItemId, pi.Label,
+		       pi.StartTrimOffsetTicks, pi.EndTrimOffsetTicks,
+		       pi.EndAction, pi.ThumbnailFilePath
+		FROM TagMap tm
+		JOIN Tag t ON t.TagId = tm.TagId AND t.Type = 2
+		JOIN PlaylistItem pi ON pi.PlaylistItemId = tm.PlaylistItemId
+		ORDER BY tm.Position`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not read playlist items: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []Item
+	index := make(map[int64]int)
+
+	for rows.Next() {
+		var (
+			it        Item
+			startTrim sql.NullInt64
+			endTrim   sql.NullInt64
+			thumb     sql.NullString
+		)
+		if err := rows.Scan(&it.Position, &it.PlaylistItemID, &it.Label,
+			&startTrim, &endTrim, &it.EndAction, &thumb); err != nil {
+			return nil, nil, fmt.Errorf("could not scan playlist item: %w", err)
+		}
+		it.StartTrimTicks = startTrim.Int64
+		it.EndTrimTicks = endTrim.Int64
+		it.ThumbnailPath = thumb.String
+
+		index[it.PlaylistItemID] = len(items)
+		items = append(items, it)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("error reading playlist items: %w", err)
+	}
+	return items, index, nil
+}
+
+// attachLocations attaches published-media references to their items.
+func attachLocations(db *sql.DB, items []Item, index map[int64]int) error {
+	rows, err := db.Query(`
+		SELECT plm.PlaylistItemId, plm.MajorMultimediaType, plm.BaseDurationTicks,
+		       l.BookNumber, l.ChapterNumber, l.DocumentId, l.Track,
+		       l.KeySymbol, l.MepsLanguage, l.Type
+		FROM PlaylistItemLocationMap plm
+		JOIN Location l ON l.LocationId = plm.LocationId`)
+	if err != nil {
+		return fmt.Errorf("could not read locations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			itemID                      int64
+			loc                         Location
+			book, chapter, docID, track sql.NullInt64
+			key                         sql.NullString
+		)
+		if err := rows.Scan(&itemID, &loc.MajorMultimediaType, &loc.BaseDurationTicks,
+			&book, &chapter, &docID, &track, &key, &loc.MepsLanguage, &loc.Type); err != nil {
+			return fmt.Errorf("could not scan location: %w", err)
+		}
+		loc.BookNumber = book.Int64
+		loc.ChapterNumber = chapter.Int64
+		loc.DocumentID = docID.Int64
+		loc.Track = track.Int64
+		loc.KeySymbol = key.String
+
+		if pos, ok := index[itemID]; ok {
+			locCopy := loc
+			items[pos].Location = &locCopy
+		}
+	}
+	return rows.Err()
+}
+
+// attachImages attaches embedded image media, marking those items image cues.
+func attachImages(db *sql.DB, items []Item, index map[int64]int) error {
+	rows, err := db.Query(`
+		SELECT pim.PlaylistItemId, pim.DurationTicks,
+		       im.OriginalFilename, im.FilePath, im.MimeType, im.Hash
+		FROM PlaylistItemIndependentMediaMap pim
+		JOIN IndependentMedia im ON im.IndependentMediaId = pim.IndependentMediaId`)
+	if err != nil {
+		return fmt.Errorf("could not read embedded media: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			itemID int64
+			img    EmbeddedImage
+		)
+		if err := rows.Scan(&itemID, &img.DurationTicks, &img.OriginalFilename,
+			&img.FilePath, &img.MimeType, &img.Hash); err != nil {
+			return fmt.Errorf("could not scan embedded media: %w", err)
+		}
+		if pos, ok := index[itemID]; ok {
+			imgCopy := img
+			items[pos].Image = &imgCopy
+		}
+	}
+	return rows.Err()
+}
+
+// attachMarkers attaches segment markers to their items, ordered by start time.
+func attachMarkers(db *sql.DB, items []Item, index map[int64]int) error {
+	rows, err := db.Query(`
+		SELECT PlaylistItemId, Label, StartTimeTicks, DurationTicks,
+		       EndTransitionDurationTicks
+		FROM PlaylistItemMarker
+		ORDER BY PlaylistItemId, StartTimeTicks`)
+	if err != nil {
+		return fmt.Errorf("could not read markers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			itemID int64
+			m      Marker
+		)
+		if err := rows.Scan(&itemID, &m.Label, &m.StartTimeTicks,
+			&m.DurationTicks, &m.EndTransitionDurationTicks); err != nil {
+			return fmt.Errorf("could not scan marker: %w", err)
+		}
+		if pos, ok := index[itemID]; ok {
+			items[pos].Markers = append(items[pos].Markers, m)
+		}
+	}
+	return rows.Err()
+}
+
+// checkZipMagic confirms the file begins with the local-file-header signature.
+func checkZipMagic(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("could not open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	magic := make([]byte, len(zipMagic))
+	if _, err := io.ReadFull(f, magic); err != nil {
+		return fmt.Errorf("not a zip archive: %s is too short", path)
+	}
+	if !bytes.Equal(magic, zipMagic) {
+		return fmt.Errorf("not a zip archive: %s does not start with the zip signature", path)
+	}
+	return nil
+}
+
+// readManifest parses manifest.json and validates the fields the parser needs.
+func readManifest(zr *zip.Reader) (manifestDoc, error) {
+	var doc manifestDoc
+
+	entry := findZipEntry(zr, "manifest.json")
+	if entry == nil {
+		return doc, fmt.Errorf("missing manifest.json in export")
+	}
+
+	rc, err := entry.Open()
+	if err != nil {
+		return doc, fmt.Errorf("could not open manifest.json: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return doc, fmt.Errorf("could not read manifest.json: %w", err)
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return doc, fmt.Errorf("manifest.json did not parse: %w", err)
+	}
+	if doc.UserDataBackup.DatabaseName == "" {
+		return doc, fmt.Errorf("manifest missing userDataBackup.databaseName")
+	}
+	if _, err := doc.UserDataBackup.SchemaVersion.Int64(); err != nil {
+		return doc, fmt.Errorf("manifest userDataBackup.schemaVersion is not an integer: %w", err)
+	}
+	return doc, nil
+}
+
+// findZipEntry returns the named entry, or nil when absent.
+func findZipEntry(zr *zip.Reader, name string) *zip.File {
+	for _, f := range zr.File {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// extractDatabase writes the database entry to tmpDir after confirming the
+// SQLite file signature.
+func extractDatabase(entry *zip.File, tmpDir string) (string, error) {
+	rc, err := entry.Open()
+	if err != nil {
+		return "", fmt.Errorf("could not open database entry %s: %w", entry.Name, err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return "", fmt.Errorf("could not read database entry %s: %w", entry.Name, err)
+	}
+	if !bytes.HasPrefix(data, []byte(sqliteMagic)) {
+		return "", fmt.Errorf("missing or non-SQLite database: %s does not start with the SQLite signature", entry.Name)
+	}
+
+	dbPath := filepath.Join(tmpDir, "userData.db")
+	if err := os.WriteFile(dbPath, data, 0o600); err != nil {
+		return "", fmt.Errorf("could not write database to temp dir: %w", err)
+	}
+	return dbPath, nil
+}
+
+// verifyTables confirms every required table is present in the database.
+func verifyTables(dbPath string) error {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return fmt.Errorf("could not open database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	present := make(map[string]bool)
+	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type = 'table'`)
+	if err != nil {
+		return fmt.Errorf("could not list database tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return fmt.Errorf("could not scan table name: %w", err)
+		}
+		present[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error reading table list: %w", err)
+	}
+
+	var missing []string
+	for _, table := range requiredTables {
+		if !present[table] {
+			missing = append(missing, table)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("database is missing required tables: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}

--- a/cmd/plt_parse_test.go
+++ b/cmd/plt_parse_test.go
@@ -1,0 +1,118 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "testing"
+
+func parseFixture(t *testing.T) *Playlist {
+	t.Helper()
+
+	path := writePlaylistFixture(t, fixtureOptions{})
+	arc, err := sniffPlaylist(path)
+	if err != nil {
+		t.Fatalf("sniff fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = arc.Close() })
+
+	pl, err := parsePlaylist(arc)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return pl
+}
+
+func TestParsePlaylist_NameAndOrder(t *testing.T) {
+	pl := parseFixture(t)
+
+	if pl.Name != "synthetic event" {
+		t.Errorf("Name = %q, want %q", pl.Name, "synthetic event")
+	}
+	if len(pl.Items) != 4 {
+		t.Fatalf("len(Items) = %d, want 4", len(pl.Items))
+	}
+	for i, it := range pl.Items {
+		if it.Position != i {
+			t.Errorf("Items[%d].Position = %d, want %d", i, it.Position, i)
+		}
+	}
+}
+
+func TestParsePlaylist_PubTrackItem(t *testing.T) {
+	song := parseFixture(t).Items[0]
+
+	if song.IsImage() {
+		t.Error("song should not be an image cue")
+	}
+	if song.Location == nil {
+		t.Fatal("song should have a Location")
+	}
+	if song.Location.KeySymbol != "sjj" || song.Location.Track != 135 {
+		t.Errorf("song location = %+v, want KeySymbol sjj track 135", song.Location)
+	}
+	if song.Location.BaseDurationTicks != 1390060000 {
+		t.Errorf("song BaseDurationTicks = %d, want 1390060000", song.Location.BaseDurationTicks)
+	}
+	if len(song.Markers) != 0 {
+		t.Errorf("song should have no markers, got %d", len(song.Markers))
+	}
+}
+
+func TestParsePlaylist_BookChapterMarkers(t *testing.T) {
+	chapter := parseFixture(t).Items[1]
+
+	if chapter.Location == nil || chapter.Location.BookNumber != 23 || chapter.Location.ChapterNumber != 5 {
+		t.Fatalf("book/chapter location = %+v, want book 23 chapter 5", chapter.Location)
+	}
+	if len(chapter.Markers) != 3 {
+		t.Fatalf("chapter markers = %d, want 3", len(chapter.Markers))
+	}
+	wantLabels := []string{"Marker one", "Marker two", "Marker three"}
+	for i, want := range wantLabels {
+		if chapter.Markers[i].Label != want {
+			t.Errorf("marker[%d].Label = %q, want %q", i, chapter.Markers[i].Label, want)
+		}
+	}
+	if chapter.Markers[0].StartTimeTicks != 20680000 {
+		t.Errorf("marker[0].StartTimeTicks = %d, want 20680000", chapter.Markers[0].StartTimeTicks)
+	}
+}
+
+func TestParsePlaylist_ImageCue(t *testing.T) {
+	img := parseFixture(t).Items[2]
+
+	if !img.IsImage() {
+		t.Fatal("third item should be an image cue")
+	}
+	if img.Location != nil {
+		t.Error("image cue should not have a Location")
+	}
+	if img.Image.DurationTicks != 40000000 {
+		t.Errorf("image DurationTicks = %d, want 40000000", img.Image.DurationTicks)
+	}
+	if img.Image.OriginalFilename != "picture.jpg" {
+		t.Errorf("image OriginalFilename = %q, want picture.jpg", img.Image.OriginalFilename)
+	}
+}
+
+func TestParsePlaylist_DocidItem(t *testing.T) {
+	doc := parseFixture(t).Items[3]
+
+	if doc.Location == nil || doc.Location.Type != 3 || doc.Location.DocumentID != 1112024040 {
+		t.Fatalf("docid location = %+v, want type 3 docid 1112024040", doc.Location)
+	}
+	if doc.Location.KeySymbol != "" {
+		t.Errorf("docid KeySymbol = %q, want empty", doc.Location.KeySymbol)
+	}
+}

--- a/cmd/plt_print_test.go
+++ b/cmd/plt_print_test.go
@@ -1,0 +1,129 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestDescribeSource(t *testing.T) {
+	cases := []struct {
+		name string
+		item Item
+		want string
+	}{
+		{
+			"pub track",
+			Item{Location: &Location{KeySymbol: "sjj", Track: 135, Type: 0}},
+			"pub sjj track 135",
+		},
+		{
+			"book/chapter",
+			Item{Location: &Location{KeySymbol: "nwt", BookNumber: 23, ChapterNumber: 5, Type: 0}},
+			"book 23:5",
+		},
+		{
+			"docid",
+			Item{Location: &Location{DocumentID: 1112024040, Track: 1, Type: 3}},
+			"docid 1112024040",
+		},
+		{
+			"image",
+			Item{Image: &EmbeddedImage{OriginalFilename: "picture.jpg"}},
+			"embedded image",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeSource(tc.item); got != tc.want {
+				t.Errorf("describeSource() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildPrintView(t *testing.T) {
+	pl := parseFixture(t)
+	view := buildPrintView(pl)
+
+	if view.Name != "synthetic event" {
+		t.Errorf("view.Name = %q", view.Name)
+	}
+	if len(view.Items) != 4 {
+		t.Fatalf("len(view.Items) = %d, want 4", len(view.Items))
+	}
+
+	song := view.Items[0]
+	if song.Source != "pub sjj track 135" {
+		t.Errorf("song.Source = %q", song.Source)
+	}
+	if math.Abs(song.DurationSec-139.006) > 1e-6 {
+		t.Errorf("song.DurationSec = %v, want 139.006", song.DurationSec)
+	}
+
+	chapter := view.Items[1]
+	if len(chapter.Markers) != 3 {
+		t.Errorf("chapter markers = %d, want 3", len(chapter.Markers))
+	}
+
+	img := view.Items[2]
+	if img.Source != "embedded image" {
+		t.Errorf("img.Source = %q", img.Source)
+	}
+	if math.Abs(img.DurationSec-4.0) > 1e-6 {
+		t.Errorf("img.DurationSec = %v, want 4.0", img.DurationSec)
+	}
+}
+
+func TestRenderJSON_RoundTrips(t *testing.T) {
+	view := buildPrintView(parseFixture(t))
+
+	var buf strings.Builder
+	if err := renderJSON(&buf, view); err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+
+	var back printView
+	if err := json.Unmarshal([]byte(buf.String()), &back); err != nil {
+		t.Fatalf("json did not round-trip: %v", err)
+	}
+	if back.Name != view.Name || len(back.Items) != len(view.Items) {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+func TestRenderText_ContainsKeyData(t *testing.T) {
+	view := buildPrintView(parseFixture(t))
+
+	var buf strings.Builder
+	if err := renderText(&buf, view); err != nil {
+		t.Fatalf("renderText: %v", err)
+	}
+	out := buf.String()
+
+	wants := []string{
+		"synthetic event", "pub sjj track 135", "book 23:5",
+		"embedded image", "docid 1112024040",
+	}
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/cmd/plt_print_test.go
+++ b/cmd/plt_print_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"encoding/json"
 	"math"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -47,6 +48,27 @@ func TestResolveInputPath(t *testing.T) {
 			t.Errorf("resolveInputPath = %q, want unchanged relative path", got)
 		}
 	})
+}
+
+func TestCheckPlaylistFile(t *testing.T) {
+	dir := t.TempDir()
+
+	present := filepath.Join(dir, "present.playlist")
+	if err := os.WriteFile(present, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := checkPlaylistFile(present); err != nil {
+		t.Errorf("existing file should pass, got: %v", err)
+	}
+
+	missing := filepath.Join(dir, "missing.playlist")
+	err := checkPlaylistFile(missing)
+	if err == nil {
+		t.Fatal("missing file should error")
+	}
+	if !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("error %q should mention 'no such file'", err.Error())
+	}
 }
 
 func TestDescribeSource(t *testing.T) {

--- a/cmd/plt_print_test.go
+++ b/cmd/plt_print_test.go
@@ -17,9 +17,37 @@ package cmd
 import (
 	"encoding/json"
 	"math"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestResolveInputPath(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "meeting.playlist")
+
+	t.Run("absolute path is unchanged", func(t *testing.T) {
+		t.Setenv("BUILD_WORKING_DIRECTORY", "/some/where")
+		if got := resolveInputPath(abs); got != abs {
+			t.Errorf("resolveInputPath(%q) = %q, want unchanged", abs, got)
+		}
+	})
+
+	t.Run("relative path joins BUILD_WORKING_DIRECTORY", func(t *testing.T) {
+		t.Setenv("BUILD_WORKING_DIRECTORY", "/launch/dir")
+		got := resolveInputPath("../export/meeting.playlist")
+		want := filepath.Join("/launch/dir", "../export/meeting.playlist")
+		if got != want {
+			t.Errorf("resolveInputPath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("relative path unchanged when env unset", func(t *testing.T) {
+		t.Setenv("BUILD_WORKING_DIRECTORY", "")
+		if got := resolveInputPath("rel/meeting.playlist"); got != "rel/meeting.playlist" {
+			t.Errorf("resolveInputPath = %q, want unchanged relative path", got)
+		}
+	})
+}
 
 func TestDescribeSource(t *testing.T) {
 	cases := []struct {

--- a/cmd/plt_sniff_test.go
+++ b/cmd/plt_sniff_test.go
@@ -1,0 +1,81 @@
+// Copyright © 2026 Kindly Ops, LLC <support@kindlyops.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSniffPlaylist_AcceptsValidRenamedFile(t *testing.T) {
+	path := writePlaylistFixture(t, fixtureOptions{})
+
+	arc, err := sniffPlaylist(path)
+	if err != nil {
+		t.Fatalf("expected valid fixture to sniff cleanly, got: %v", err)
+	}
+	t.Cleanup(func() { _ = arc.Close() })
+
+	if arc.schemaVersion != verifiedSchemaVersion {
+		t.Errorf("schemaVersion = %d, want %d", arc.schemaVersion, verifiedSchemaVersion)
+	}
+	if arc.dbPath == "" {
+		t.Error("expected dbPath to be populated")
+	}
+}
+
+func TestSniffPlaylist_Rejections(t *testing.T) {
+	cases := []struct {
+		name        string
+		opts        fixtureOptions
+		wantInError string
+	}{
+		{"not a zip", fixtureOptions{notZip: true}, "not a zip archive"},
+		{"missing manifest", fixtureOptions{omitManifest: true}, "manifest"},
+		{"non-sqlite database", fixtureOptions{corruptDB: true}, "SQLite"},
+		{"missing required table", fixtureOptions{omitTables: []string{"PlaylistItemMarker"}}, "PlaylistItemMarker"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writePlaylistFixture(t, tc.opts)
+
+			arc, err := sniffPlaylist(path)
+			if arc != nil {
+				_ = arc.Close()
+			}
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.wantInError)
+			}
+		})
+	}
+}
+
+func TestSniffPlaylist_UnverifiedSchemaProceeds(t *testing.T) {
+	path := writePlaylistFixture(t, fixtureOptions{schemaVersion: 99})
+
+	arc, err := sniffPlaylist(path)
+	if err != nil {
+		t.Fatalf("unverified schema version should still parse, got: %v", err)
+	}
+	t.Cleanup(func() { _ = arc.Close() })
+
+	if arc.schemaVersion != 99 {
+		t.Errorf("schemaVersion = %d, want 99", arc.schemaVersion)
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -43,6 +43,7 @@ func TestRootCommand_HasSubcommands(t *testing.T) {
 		"chapterlist",
 		"chaptersplit",
 		"serve",
+		"plt",
 	}
 
 	availableCommands := make(map[string]bool)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/labstack/echo/v5 v5.0.0-20220201181537-ed2888cfa198
 	github.com/muesli/coral v1.0.0
 	github.com/pocketbase/pocketbase v0.16.5
+	modernc.org/sqlite v1.22.1
 )
 
 require (
@@ -117,7 +118,6 @@ require (
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect
 	modernc.org/opt v0.1.3 // indirect
-	modernc.org/sqlite v1.22.1 // indirect
 	modernc.org/strutil v1.1.3 // indirect
 	modernc.org/token v1.1.0 // indirect
 )

--- a/scripts/check-vendor-neutral.sh
+++ b/scripts/check-vendor-neutral.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Vendor-neutrality guard.
+#
+# The originating app's publisher is referred to only in generic terms in this
+# repository ("the source app", "the publisher's media API"). The publisher's
+# two-letter abbreviation, full name, app name, domains, and file extension must
+# never appear in files we author.
+#
+# The forbidden abbreviation is expressed below as a character class so this
+# script does not itself contain the literal text; case-insensitive matching
+# covers upper/lower case.
+#
+# Out of scope: third-party code (vendor/), Go dependency manifests
+# (go.mod, go.sum) and the Bazel lock file, which legitimately reference an
+# unrelated token-handling module whose name happens to contain the same two
+# letters, and binary assets.
+
+pattern='j[w]'
+
+matches=$(
+	git grep -i -I -nE "$pattern" -- \
+		':!vendor/' \
+		':!go.mod' \
+		':!go.sum' \
+		':!MODULE.bazel.lock' \
+		':!*.png' ':!*.jpg' ':!*.jpeg' ':!*.ico' ':!*.svg' \
+		':!*.woff' ':!*.woff2' ':!*.ttf' || true
+)
+
+if [[ -n "$matches" ]]; then
+	echo "Vendor-neutrality guard FAILED: forbidden publisher string found in committed files:" >&2
+	echo "$matches" >&2
+	echo >&2
+	echo "Use the generic terms instead (see scripts/check-vendor-neutral.sh)." >&2
+	exit 1
+fi
+
+echo "Vendor-neutrality guard passed: no forbidden publisher string in authored files."


### PR DESCRIPTION
## Summary

First phase of the `plt` command group for working with purple playlist
exports (a ZIP container holding a SQLite database, produced by the source
app for queuing media in live events).

This phase delivers `vbs plt print <playlist>`, which parses a playlist and
prints its cues offline — no media is downloaded.

- **Format sniffer** detects playlists by content, not file extension, and
  rejects invalid files with a named reason (not a zip, missing manifest,
  non-SQLite database, or missing required tables). Unverified schema
  versions warn but proceed when the required tables are present.
- **Parser** reads the verified table contract into an ordered domain model:
  items, published-media locations (pub/track, book/chapter, docid shapes), embedded
  image cues, and segment markers.
- **`plt print`** renders an aligned table (position, label, source, duration,
  marker count, raw end action) with a `--json` flag for the same data.
- **Synthetic fixture generator** builds playlist zips in-test (SQLite +
  manifest + 1×1 JPEGs) covering every source shape, so tests never depend on
  real exports.
- **Vendor-neutrality guard** (`scripts/check-vendor-neutral.sh`, wired into
  the lint workflow) rejects the publisher's identifiers in authored files.

`modernc.org/sqlite` (pure-Go, no CGO) is promoted from an indirect to a
direct dependency.

## Test Plan

- [x] `go test ./cmd/` green (helpers, sniffer, parser, print; tick
      conversion, slugging, language resolution, all four source shapes)
- [x] `bazel build //cmd:go_default_library` and `bazel test //cmd:go_default_test` green
- [x] `gofmt`, `go vet ./cmd/`, `go build ./...`, `go mod verify` clean
- [x] funlen / gocyclo / lll within limits
- [x] Manually verified against a real 15-item export: 15 items, 10 markers
      across 8 items, 1 image cue, correct source descriptions
- [x] Vendor guard passes on the tree and fails on an injected string
