### PR TITLE
Support schema v14-v16 playlists in plt subcommand

### DIFF
--- a/cmd/plt.go
+++ b/cmd/plt.go
@@ -55,9 +55,9 @@ func runPltPrint(_ *coral.Command, args []string) {
 	arc := openPlaylist(args[0])
 	defer func() { _ = arc.Close() }()
 
-	if arc.schemaVersion != verifiedSchemaVersion {
-		log.Warn().Msgf("schema version %d differs from verified version %d; proceeding because required tables are present",
-			arc.schemaVersion, verifiedSchemaVersion)
+	if !schemaVersionVerified(arc.schemaVersion) {
+		log.Warn().Msgf("schema version %d is outside the verified range %d-%d; proceeding because required tables are present",
+			arc.schemaVersion, minVerifiedSchemaVersion, maxVerifiedSchemaVersion)
 	}
 
 	pl, err := parsePlaylist(arc)

--- a/cmd/plt.go
+++ b/cmd/plt.go
@@ -56,7 +56,7 @@ func runPltPrint(_ *coral.Command, args []string) {
 	defer func() { _ = arc.Close() }()
 
 	if !schemaVersionVerified(arc.schemaVersion) {
-		log.Warn().Msgf("schema version %d is outside the verified range %d-%d; proceeding because required tables are present",
+		log.Warn().Msgf("schema version %d outside verified range %d-%d; proceeding because required tables are present",
 			arc.schemaVersion, minVerifiedSchemaVersion, maxVerifiedSchemaVersion)
 	}
 

--- a/cmd/plt_fixture_test.go
+++ b/cmd/plt_fixture_test.go
@@ -76,7 +76,7 @@ func writePlaylistFixture(t *testing.T, opts fixtureOptions) string {
 	files := map[string][]byte{
 		dbName:            dbBytes,
 		fixtureThumbA:     onePixelJPEG(t),
-		fixtureThumbBook: onePixelJPEG(t),
+		fixtureThumbBook:  onePixelJPEG(t),
 		fixtureThumbImage: onePixelJPEG(t),
 		fixtureThumbDocid: onePixelJPEG(t),
 		fixtureImageFile:  onePixelJPEG(t),

--- a/cmd/plt_fixture_test.go
+++ b/cmd/plt_fixture_test.go
@@ -95,7 +95,7 @@ func fixtureManifest(t *testing.T, dbName string, schemaVersion int) []byte {
 	t.Helper()
 
 	if schemaVersion == 0 {
-		schemaVersion = verifiedSchemaVersion
+		schemaVersion = minVerifiedSchemaVersion
 	}
 
 	manifest := map[string]any{

--- a/cmd/plt_parse.go
+++ b/cmd/plt_parse.go
@@ -32,10 +32,22 @@ const sqliteMagic = "SQLite format 3\x00"
 
 var zipMagic = []byte("PK\x03\x04")
 
-// verifiedSchemaVersion is the source-app backup schema version this parser
-// was validated against. Other versions warn but still proceed when the
+// minVerifiedSchemaVersion and maxVerifiedSchemaVersion bound the inclusive
+// range of source-app backup schema versions this parser has been validated
+// against. Versions within the range are known to be compatible: the newer
+// ones only add tables and columns the parser ignores, leaving every column it
+// reads unchanged. Versions outside the range warn but still proceed when the
 // required tables are present — the tables are the real contract.
-const verifiedSchemaVersion = 14
+const (
+	minVerifiedSchemaVersion = 14
+	maxVerifiedSchemaVersion = 16
+)
+
+// schemaVersionVerified reports whether v falls within the inclusive range of
+// schema versions this parser has been validated against.
+func schemaVersionVerified(v int) bool {
+	return v >= minVerifiedSchemaVersion && v <= maxVerifiedSchemaVersion
+}
 
 // requiredTables are the database tables the parser depends on. Their presence
 // is the contract that lets us read a playlist regardless of schema version.

--- a/cmd/plt_sniff_test.go
+++ b/cmd/plt_sniff_test.go
@@ -28,8 +28,8 @@ func TestSniffPlaylist_AcceptsValidRenamedFile(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = arc.Close() })
 
-	if arc.schemaVersion != verifiedSchemaVersion {
-		t.Errorf("schemaVersion = %d, want %d", arc.schemaVersion, verifiedSchemaVersion)
+	if arc.schemaVersion != minVerifiedSchemaVersion {
+		t.Errorf("schemaVersion = %d, want %d", arc.schemaVersion, minVerifiedSchemaVersion)
 	}
 	if arc.dbPath == "" {
 		t.Error("expected dbPath to be populated")
@@ -77,5 +77,55 @@ func TestSniffPlaylist_UnverifiedSchemaProceeds(t *testing.T) {
 
 	if arc.schemaVersion != 99 {
 		t.Errorf("schemaVersion = %d, want 99", arc.schemaVersion)
+	}
+}
+
+// TestSniffPlaylist_AcceptsSchemaV16 covers the newer verified schema version.
+// v16 only adds tables and columns the parser ignores, so the cues it reads are
+// unchanged and the export sniffs and parses like any other verified version.
+func TestSniffPlaylist_AcceptsSchemaV16(t *testing.T) {
+	path := writePlaylistFixture(t, fixtureOptions{schemaVersion: 16})
+
+	arc, err := sniffPlaylist(path)
+	if err != nil {
+		t.Fatalf("schema v16 should sniff cleanly, got: %v", err)
+	}
+	t.Cleanup(func() { _ = arc.Close() })
+
+	if arc.schemaVersion != 16 {
+		t.Errorf("schemaVersion = %d, want 16", arc.schemaVersion)
+	}
+	if !schemaVersionVerified(arc.schemaVersion) {
+		t.Errorf("schema v16 should be within the verified range %d-%d",
+			minVerifiedSchemaVersion, maxVerifiedSchemaVersion)
+	}
+
+	pl, err := parsePlaylist(arc)
+	if err != nil {
+		t.Fatalf("parse schema v16: %v", err)
+	}
+	if len(pl.Items) != 4 {
+		t.Errorf("len(Items) = %d, want 4", len(pl.Items))
+	}
+}
+
+// TestSchemaVersionVerified pins the inclusive verified range so the warning
+// gate trips only for versions outside it.
+func TestSchemaVersionVerified(t *testing.T) {
+	cases := []struct {
+		version int
+		want    bool
+	}{
+		{13, false},
+		{14, true},
+		{15, true},
+		{16, true},
+		{17, false},
+		{99, false},
+	}
+	for _, tc := range cases {
+		if got := schemaVersionVerified(tc.version); got != tc.want {
+			t.Errorf("schemaVersionVerified(%d) = %v, want %v", tc.version, got, tc.want)
+		}
 	}
 }

--- a/cmd/plt_sniff_test.go
+++ b/cmd/plt_sniff_test.go
@@ -84,34 +84,41 @@ func TestSniffPlaylist_UnverifiedSchemaProceeds(t *testing.T) {
 // v16 only adds tables and columns the parser ignores, so the cues it reads are
 // unchanged and the export sniffs and parses like any other verified version.
 func TestSniffPlaylist_AcceptsSchemaV16(t *testing.T) {
-	path := writePlaylistFixture(t, fixtureOptions{schemaVersion: 16})
+	t.Parallel()
+
+	path := writePlaylistFixture(t, fixtureOptions{schemaVersion: 16}) //nolint:exhaustruct // fixture defaults
 
 	arc, err := sniffPlaylist(path)
 	if err != nil {
 		t.Fatalf("schema v16 should sniff cleanly, got: %v", err)
 	}
+
 	t.Cleanup(func() { _ = arc.Close() })
 
 	if arc.schemaVersion != 16 {
 		t.Errorf("schemaVersion = %d, want 16", arc.schemaVersion)
 	}
+
 	if !schemaVersionVerified(arc.schemaVersion) {
 		t.Errorf("schema v16 should be within the verified range %d-%d",
 			minVerifiedSchemaVersion, maxVerifiedSchemaVersion)
 	}
 
-	pl, err := parsePlaylist(arc)
+	playlist, err := parsePlaylist(arc)
 	if err != nil {
 		t.Fatalf("parse schema v16: %v", err)
 	}
-	if len(pl.Items) != 4 {
-		t.Errorf("len(Items) = %d, want 4", len(pl.Items))
+
+	if len(playlist.Items) != 4 {
+		t.Errorf("len(Items) = %d, want 4", len(playlist.Items))
 	}
 }
 
 // TestSchemaVersionVerified pins the inclusive verified range so the warning
 // gate trips only for versions outside it.
 func TestSchemaVersionVerified(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		version int
 		want    bool


### PR DESCRIPTION
## Summary

Ports the playlist schema-version change from [cuesheet#15](https://github.com/kindlyops/cuesheet/pull/15) to the `plt` subcommand, kept vendor neutral.

The parser previously treated only schema version **14** as verified, warning on anything else. A real newer export declares `schemaVersion: 16`, whose schema changes are purely **additive** — it only adds tables and columns the parser ignores (an item accuracy lookup, extra location fields, new marker mapping tables). Every column the parser actually reads is unchanged, so 15 and 16 are known-compatible and should not trip the warning.

## Changes

- Replace the single `verifiedSchemaVersion` constant with inclusive bounds `minVerifiedSchemaVersion = 14` / `maxVerifiedSchemaVersion = 16` plus a `schemaVersionVerified` helper.
- `plt print` now warns (and still proceeds) only when the version is **outside** the verified range, and the message reports the supported range.
- Add a v16 sniff/parse test and a unit test pinning the verified range boundaries.

Parsing already proceeds for any version when the required tables are present, so out-of-range versions (e.g. 99) continue to parse with a warning as before.

## Testing

- `go test ./cmd/` (plt sniff/parse/print suites) ✅
- `go vet ./cmd/` ✅

Note: the cuesheet PR also includes mobile web-app (`site/`) fixes, which are out of scope for the `plt` subcommand and not ported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSfuxQeqxp72A9sJDvX3dX)_