### PR TITLE
Fix release binary swap and plt build on image-only playlists

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - windows_amd64
     binary: vbs
     hooks:
-      post: pwsh goreleaser-post-hook.ps1
+      post: pwsh goreleaser-post-hook.ps1 {{ .Os }} {{ .Arch }}
 
 checksum:
   name_template: 'checksums.txt'
@@ -27,7 +27,7 @@ announce:
     message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }} or brew upgrade {{ .ProjectName }}'
     author: 'GoReleaser'
 
-brews:
+homebrew_casks:
   - repository:
       owner: kindlyops
       name: homebrew-tap
@@ -59,15 +59,14 @@ brews:
     # Default is empty.
     description: "vbs helps work with video broadcast files and streams."
 
-    # So you can `brew test` your formula.
-    # Default is empty.
-    test: |
-      system "#{bin}/vbs --version"
-
-    # Custom install script for brew.
-    # Default is 'bin.install "program"'.
-    install: |
-      bin.install "vbs"
+    # vbs ships unsigned, so macOS quarantines the downloaded binary and refuses
+    # to run it ("vbs is damaged"). Strip the quarantine attribute on install.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/vbs"]
+          end
 
 scoops:
   - # Template for the url which is determined by the given Token (github or gitlab)

--- a/cmd/plt_build.go
+++ b/cmd/plt_build.go
@@ -312,6 +312,11 @@ func (ctx *buildContext) cutCues(
 // resolveMedia downloads and caches the rendition for a location, memoizing by
 // query URL so a location referenced by several items is fetched once.
 func (ctx *buildContext) resolveMedia(loc *Location) (resolvedMedia, error) {
+	if ctx.langCode == "" {
+		return resolvedMedia{}, fmt.Errorf(
+			"unknown language id %d; set it explicitly with --lang", ctx.langID)
+	}
+
 	endpoint, err := buildMediaURL(ctx.base, ctx.langCode, loc)
 	if err != nil {
 		return resolvedMedia{}, err

--- a/cmd/plt_helpers.go
+++ b/cmd/plt_helpers.go
@@ -35,11 +35,17 @@ func ticksToSeconds(ticks int64) float64 {
 }
 
 // resolveLanguage returns the written-language code for a MepsLanguage ID.
-// A non-empty override always wins; otherwise the embedded map is consulted
-// and an unmapped ID is a fatal error naming the override flag.
+// A non-empty override always wins. An ID of 0 means no located item dictated a
+// language (e.g. an image-only playlist), which is not an error here: an empty
+// code is returned and any download that genuinely needs a language enforces it
+// at fetch time. A non-zero, unmapped ID is a fatal error naming the flag.
 func resolveLanguage(id int, override string) (string, error) {
 	if override != "" {
 		return override, nil
+	}
+
+	if id == 0 {
+		return "", nil
 	}
 
 	if code, ok := languageNames[id]; ok {

--- a/cmd/plt_helpers_test.go
+++ b/cmd/plt_helpers_test.go
@@ -54,6 +54,8 @@ func TestResolveLanguage(t *testing.T) {
 		{"override wins over known", 420, "ESL", "ESL", false},
 		{"override fills unknown", 999, "FOO", "FOO", false},
 		{"unknown id is fatal", 999, "", "", true},
+		{"id 0 is not fatal", 0, "", "", false},
+		{"override wins over id 0", 0, "ASL", "ASL", false},
 	}
 
 	for _, tc := range cases {

--- a/dummy.go
+++ b/dummy.go
@@ -1,7 +1,27 @@
 //go:build neverbuild
 // +build neverbuild
 
+// This file is the placeholder main that goreleaser compiles (see
+// .goreleaser.yml `main: dummy.go`). The real binary is built by bazel and
+// swapped into goreleaser's dist directory by goreleaser-post-hook.ps1. The
+// neverbuild constraint keeps `go build ./...`, `go test`, and bazel from
+// picking up this empty main; goreleaser bypasses the constraint because it
+// names the file explicitly on the `go build` command line.
+//
+// If you are seeing this message at runtime, the bazel binary was NOT swapped
+// in during release and the placeholder shipped instead. That is a packaging
+// bug, not a usable build of vbs.
 package main
 
+import (
+	"fmt"
+	"os"
+)
+
 func main() {
+	fmt.Fprintln(os.Stderr,
+		"vbs: this is the placeholder build; the real binary was not packaged "+
+			"during release. Please report this at "+
+			"https://github.com/kindlyops/vbs/issues")
+	os.Exit(1)
 }

--- a/goreleaser-post-hook.ps1
+++ b/goreleaser-post-hook.ps1
@@ -1,9 +1,36 @@
 #!/usr/bin/env pwsh
 
-Write-Output "moving bazel outputs to goreleaser dist directory for packaging..."
+# goreleaser compiles the placeholder dummy.go (see .goreleaser.yml). This hook
+# replaces one target's placeholder binary in goreleaser's dist directory with
+# the real binary that bazel built under bazel-bin/bdist, before goreleaser
+# archives it. goreleaser runs the post hook once per target in parallel and
+# passes that target's os and arch, so each invocation swaps only its own
+# binary (copying every binary on every invocation would race).
+#
+# goreleaser v2 appends a CPU microarchitecture level to each output directory
+# (e.g. vbs_darwin_arm64_v8.0, vbs_linux_amd64_v1), while bazel emits plain
+# vbs_<os>_<arch> directories. Match by os/arch prefix so the swap keeps working
+# regardless of which microarchitecture suffix goreleaser chooses.
 
-if (-Not (Test-Path "dist")) {
-  New-Item -Force -Path (Get-Location).Path -Name "dist" -ItemType "directory"
+param(
+    [Parameter(Mandatory = $true)][string]$Os,
+    [Parameter(Mandatory = $true)][string]$Arch
+)
+
+$ErrorActionPreference = "Stop"
+
+$name = "vbs_${Os}_${Arch}"
+$srcDir = Join-Path (Resolve-Path "bazel-bin/bdist") $name
+if (-Not (Test-Path $srcDir)) {
+    throw "no bazel output at $srcDir for target $Os/$Arch"
 }
 
-Copy-Item (Resolve-Path "bazel-bin/bdist/*") -Destination (Resolve-Path "dist") -Recurse -Force
+$destDirs = Get-ChildItem -Path "dist" -Directory -Filter "$name*"
+if ($destDirs.Count -eq 0) {
+    throw "no goreleaser dist directory matches $name; cannot swap in the bazel binary"
+}
+
+foreach ($destDir in $destDirs) {
+    Copy-Item -Path (Join-Path $srcDir "*") -Destination $destDir.FullName -Recurse -Force
+    Write-Output "swapped bazel binary $name -> dist/$($destDir.Name)"
+}


### PR DESCRIPTION
## Release pipeline shipped the placeholder dummy binary

`vbs` installed from the homebrew tap exited with no output. The shipped binary was the do-nothing `dummy.go` placeholder, not the real bazel-built binary.

The pipeline compiles `dummy.go` with goreleaser, then a post-hook swaps in the bazel binary before archiving. goreleaser v2 appends a CPU microarchitecture level to each output directory (`vbs_darwin_arm64_v8.0`, `vbs_linux_amd64_v1`, ...), but the post-hook copied the bazel binaries into the un-suffixed `vbs_<os>_<arch>` dirs — so goreleaser archived the dummy and the real 48 MB binary was ignored.

- `goreleaser-post-hook.ps1`: match goreleaser dist dirs by os/arch prefix and swap per target. goreleaser passes the target's os/arch and runs the hook in parallel, so each invocation swaps only its own binary.
- `dummy.go`: the placeholder `main` now prints an error to stderr and exits 1 instead of exiting 0 silently, so a future failed swap is detectable instead of silent.
- `.goreleaser.yml`: migrate the deprecated `brews` block to `homebrew_casks` (goreleaser removed the formula path in v2.16). Adds a `postflight` `xattr` hook to strip the macOS quarantine bit, since the binary is unsigned.

Verified with `goreleaser release --snapshot`: archives now contain the real binary and it runs.

## `plt build` failed on image-only playlists

`vbs plt build` on a picture-only playlist aborted with `unknown language id 0; set it explicitly with --lang`. The language is inferred from the first item with a video `Location`; an image-only playlist has none, so the id was 0 and treated as fatal — but images are extracted from the archive and need no language.

- `resolveLanguage`: treat id 0 (no language determined) as non-fatal; a non-zero unmappable id stays fatal.
- `plt_build.go`: enforce a language at download time, where it is actually needed, so video items with an unresolved language still error clearly.
- Added test cases for the id-0 path.

Verified: build now completes on the image playlist; `cmd` test suite passes.

## Follow-up needed in the tap repo (not in this PR)
The cask migration needs a one-time manual step in `kindlyops/homebrew-tap`: add a `tap_migrations.json` mapping the old formula to the cask and delete the old `Formula/vbs.rb`, so existing users upgrade cleanly.