### PR TITLE
Remove Discord announce from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,12 +21,6 @@ checksum:
 sboms:
   - artifacts: archive
 
-announce:
-  discord:
-    enabled: true
-    message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }} or brew upgrade {{ .ProjectName }}'
-    author: 'GoReleaser'
-
 homebrew_casks:
   - repository:
       owner: kindlyops


### PR DESCRIPTION
## What

Removes the `announce.discord` block from `.goreleaser.yml`.

## Why

The release GitHub Actions workflow fails when posting to Discord. Dropping the announce block lets releases complete successfully.